### PR TITLE
Ensure original memory is not written.

### DIFF
--- a/dll/src/ReflectiveLoader.c
+++ b/dll/src/ReflectiveLoader.c
@@ -73,6 +73,7 @@ DLLEXPORT UINT_PTR WINAPI ReflectiveLoader( VOID )
 	UINT_PTR uiValueB;
 	UINT_PTR uiValueC;
 	UINT_PTR uiValueD;
+	UINT_PTR uiValueE;
 
 	// STEP 0: calculate our images current base address
 
@@ -220,7 +221,8 @@ DLLEXPORT UINT_PTR WINAPI ReflectiveLoader( VOID )
 	uiValueA = ( (UINT_PTR)&((PIMAGE_NT_HEADERS)uiHeaderValue)->OptionalHeader + ((PIMAGE_NT_HEADERS)uiHeaderValue)->FileHeader.SizeOfOptionalHeader );
 	
 	// itterate through all sections, loading them into memory.
-	while( ((PIMAGE_NT_HEADERS)uiHeaderValue)->FileHeader.NumberOfSections-- )
+	uiValueE = ((PIMAGE_NT_HEADERS)uiHeaderValue)->FileHeader.NumberOfSections;
+	while( uiValueE-- )
 	{
 		// uiValueB is the VA for this section
 		uiValueB = ( uiBaseAddress + ((PIMAGE_SECTION_HEADER)uiValueA)->VirtualAddress );


### PR DESCRIPTION
If ReflectiveLoader is being executed from non-writable memory (say RX only) then it crashes on the decrement. Using stack to store the section count for use in the while(..) loop makes the ReflectiveLoader code independent of writable memory.
